### PR TITLE
Pubchem annotator

### DIFF
--- a/src/pyBiodatafuse/annotators/pubchem.py
+++ b/src/pyBiodatafuse/annotators/pubchem.py
@@ -111,32 +111,19 @@ def get_protein_molecule_screened(bridgedb_df: pd.DataFrame) -> Tuple[pd.DataFra
         "http://www.bioassayontology.org/bao#BAO_0000186": "AC50",
         "http://www.bioassayontology.org/bao#BAO_0000187": "CC50",
         "http://www.bioassayontology.org/bao#BAO_0000188": "EC50",
-        "http://www.bioassayontology.org/bao#BAO_0000189": "GI50",
         "http://www.bioassayontology.org/bao#BAO_0000190": "IC50",
         "http://www.bioassayontology.org/bao#BAO_0000192": "Ki",
-        "http://www.bioassayontology.org/bao#BAO_0000194": "TGI",
-        "http://www.bioassayontology.org/bao#BAO_0000349": "50 percent cell viability",
-        "http://www.bioassayontology.org/bao#BAO_0000477": "km",
-        "http://www.bioassayontology.org/bao#BAO_0002117": "LD50",
-        "http://www.bioassayontology.org/bao#BAO_0002144": "IC90",
-        "http://www.bioassayontology.org/bao#BAO_0002145": "LC50",
         "http://www.bioassayontology.org/bao#BAO_0002146": "MIC",
-        "http://www.bioassayontology.org/bao#BAO_0002162": "concentration response endpoint",
-        "http://www.bioassayontology.org/bao#BAO_0002862": "EC 5 hour",
-        "http://www.bioassayontology.org/bao#BAO_0002877": "AC1000 absolute",
-        "http://www.bioassayontology.org/bao#BAO_0002878": "AC10 absolute",
-        "http://www.bioassayontology.org/bao#BAO_0002879": "AC26 absolute",
-        "http://www.bioassayontology.org/bao#BAO_0002880": "AC35 absolute",
-        "http://www.bioassayontology.org/bao#BAO_0002881": "AC40 absolute",
-        "http://www.bioassayontology.org/bao#BAO_0002882": "AC500 absolute",
-        "http://www.bioassayontology.org/bao#BAO_0002883": "ECMax",
-        "http://www.bioassayontology.org/bao#BAO_0002884": "ECMax_Tm",
-        "http://www.bioassayontology.org/bao#BAO_0002886": "ECMax_fold increase",
-        "http://www.bioassayontology.org/bao#BAO_0002887": "ECMax_percent inhibition",
-        "http://www.bioassayontology.org/bao#BAO_0003036": "ED50",
     }
 
     if not intermediate_df.empty:
+        # drop multitarget assays
+        intermediate_df["target_count"] = intermediate_df["target_count"].map(lambda x: int(x))
+        intermediate_df = intermediate_df.drop(
+            intermediate_df[intermediate_df["target_count"] > 1].index
+        )
+        intermediate_df = intermediate_df.drop(columns=["target_count"])
+        # identifiers to values
         intermediate_df["target"] = intermediate_df["target"].map(lambda x: x[32:])
         intermediate_df["outcome"] = intermediate_df["outcome"].map(lambda x: x[47:])
         intermediate_df["compound_cid"] = intermediate_df["compound_cid"].map(lambda x: x[48:])

--- a/src/pyBiodatafuse/annotators/pubchem.py
+++ b/src/pyBiodatafuse/annotators/pubchem.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Python file for queriying PubChem SPARQL endpoint at https://idsm.elixir-czech.cz/sparql/endpoint/idsm."""
+
+import datetime
+import os
+from string import Template
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+from SPARQLWrapper import JSON, SPARQLWrapper
+
+from pyBiodatafuse.utils import collapse_data_sources, get_identifier_of_interest
+
+
+def get_protein_molecule_screened(bridgedb_df: pd.DataFrame) -> Tuple[pd.DataFrame, dict]:
+    """Query PubChem for molecules screened on proteins as targets.
+
+    :param bridgedb_df: BridgeDb output for creating the list of gene ids to query.
+    :returns: a DataFrame containing the PubChem output and dictionary of the PubChem metadata.
+    """
+    # Record the start time
+    start_time = datetime.datetime.now()
+
+    data_df = get_identifier_of_interest(bridgedb_df, "Uniprot-TrEMBL")
+    protein_list_str = data_df["target"].tolist()
+    for i in range(len(protein_list_str)):
+        protein_list_str[i] = "<http://purl.uniprot.org/uniprot/" + protein_list_str[i] + ">"
+
+    protein_list_str = list(set(protein_list_str))
+
+    query_protein_list = []
+
+    if len(protein_list_str) > 25:
+        for i in range(0, len(protein_list_str), 25):
+            tmp_list = protein_list_str[i : i + 25]
+            query_protein_list.append(" ".join(f"{g}" for g in tmp_list))
+
+    else:
+        query_protein_list.append(" ".join(f"{g}" for g in protein_list_str))
+
+    with open(
+        os.path.dirname(__file__) + "/queries/pubchem-proteins-screend-molecule.rq", "r"
+    ) as fin:
+        sparql_query = fin.read()
+
+    sparql = SPARQLWrapper("https://idsm.elixir-czech.cz/sparql/endpoint/idsm")
+    sparql.setReturnFormat(JSON)
+    sparql.setOnlyConneg(True)
+
+    query_count = 0
+
+    results_df_list = list()
+
+    for protein_list_str in query_protein_list:
+        query_count += 1
+
+        sparql_query_template = Template(sparql_query)
+        substit_dict = dict(protein_list=protein_list_str)
+        sparql_query_template_sub = sparql_query_template.substitute(substit_dict)
+
+        sparql.setQuery(sparql_query_template_sub)
+        res = sparql.queryAndConvert()
+
+        df = pd.DataFrame(res["results"]["bindings"])
+        df = df.applymap(lambda x: x["value"], na_action="ignore")
+
+        results_df_list.append(df)
+
+    # Record the end time
+    end_time = datetime.datetime.now()
+
+    # Organize the annotation results as an array of dictionaries
+    intermediate_df = pd.concat(results_df_list)
+
+    intermediate_df.rename(columns={"upProt": "target"}, inplace=True)
+
+    endpoint_types = {
+        "http://www.bioassayontology.org/bao#BAO_0000034": "Kd",
+        "http://www.bioassayontology.org/bao#BAO_0000186": "AC50",
+        "http://www.bioassayontology.org/bao#BAO_0000187": "CC50",
+        "http://www.bioassayontology.org/bao#BAO_0000188": "EC50",
+        "http://www.bioassayontology.org/bao#BAO_0000189": "GI50",
+        "http://www.bioassayontology.org/bao#BAO_0000190": "IC50",
+        "http://www.bioassayontology.org/bao#BAO_0000192": "Ki",
+        "http://www.bioassayontology.org/bao#BAO_0000194": "TGI",
+        "http://www.bioassayontology.org/bao#BAO_0000349": "50 percent cell viability",
+        "http://www.bioassayontology.org/bao#BAO_0000477": "km",
+        "http://www.bioassayontology.org/bao#BAO_0002117": "LD50",
+        "http://www.bioassayontology.org/bao#BAO_0002144": "IC90",
+        "http://www.bioassayontology.org/bao#BAO_0002145": "LC50",
+        "http://www.bioassayontology.org/bao#BAO_0002146": "MIC",
+        "http://www.bioassayontology.org/bao#BAO_0002162": "concentration response endpoint",
+        "http://www.bioassayontology.org/bao#BAO_0002862": "EC 5 hour",
+        "http://www.bioassayontology.org/bao#BAO_0002877": "AC1000 absolute",
+        "http://www.bioassayontology.org/bao#BAO_0002878": "AC10 absolute",
+        "http://www.bioassayontology.org/bao#BAO_0002879": "AC26 absolute",
+        "http://www.bioassayontology.org/bao#BAO_0002880": "AC35 absolute",
+        "http://www.bioassayontology.org/bao#BAO_0002881": "AC40 absolute",
+        "http://www.bioassayontology.org/bao#BAO_0002882": "AC500 absolute",
+        "http://www.bioassayontology.org/bao#BAO_0002883": "ECMax",
+        "http://www.bioassayontology.org/bao#BAO_0002884": "ECMax_Tm",
+        "http://www.bioassayontology.org/bao#BAO_0002886": "ECMax_fold increase",
+        "http://www.bioassayontology.org/bao#BAO_0002887": "ECMax_percent inhibition",
+        "http://www.bioassayontology.org/bao#BAO_0003036": "ED50",
+    }
+
+    if not intermediate_df.empty:
+        intermediate_df["target"] = intermediate_df["target"].map(lambda x: x[32:])
+        intermediate_df["outcome"] = intermediate_df["outcome"].map(lambda x: x[47:])
+        intermediate_df["compound_cid"] = intermediate_df["compound_cid"].map(lambda x: x[48:])
+        intermediate_df["assay_type"] = intermediate_df["assay_type"].map(
+            lambda x: endpoint_types[x]
+        )
+        target_columns = list(intermediate_df.columns)
+        target_columns.remove("target")
+    else:
+        target_columns = list(intermediate_df.columns)
+
+    # Merge the two DataFrames on the target column
+    merged_df = collapse_data_sources(
+        data_df=data_df,
+        source_namespace="Uniprot-TrEMBL",
+        target_df=intermediate_df,
+        common_cols=["target"],
+        target_specific_cols=target_columns,
+        col_name="compounds_screened",
+    )
+
+    # if mappings exist but SPARQL returns empty response
+    if (not merged_df.empty) and merged_df["compounds_screened"][0] is None:
+        merged_df.drop_duplicates(subset=["identifier", "compounds_screened"], inplace=True)
+    elif not merged_df.empty:
+        res_keys = merged_df["compounds_screened"][0][0].keys()
+        # remove duplicate identifier and response row
+        merged_df["compounds_screened"] = merged_df["compounds_screened"].map(
+            lambda x: tuple(frozenset(d.items()) for d in x), na_action="ignore"
+        )
+        merged_df.drop_duplicates(subset=["identifier", "compounds_screened"], inplace=True)
+        merged_df["compounds_screened"] = merged_df["compounds_screened"].map(
+            lambda res_tup: list(dict((x, y) for x, y in res) for res in res_tup),
+            na_action="ignore",
+        )
+
+        # drop rows with duplicate identifiers with empty response
+        identifiers = merged_df["identifier"].unique()
+        for identifier in identifiers:
+            if merged_df.loc[merged_df["identifier"] == identifier].shape[0] > 1:
+                mask = merged_df["compounds_screened"].apply(
+                    lambda lst: all(
+                        [
+                            all([isinstance(val, float) and np.isnan(val) for val in dct.values()])
+                            for dct in lst
+                        ]
+                    )
+                )
+                mask2 = merged_df["identifier"].apply(lambda x, id=identifier: x == id)
+                merged_df.drop(merged_df[mask & mask2].index, inplace=True)
+
+        # set default order to response dictionaries to keep output consistency
+        merged_df["compounds_screened"] = merged_df["compounds_screened"].apply(
+            lambda res: list(dict((k, r[k]) for k in res_keys) for r in res)
+        )
+        # set numerical identifiers to int to kepp output consistency
+        merged_df["compounds_screened"] = merged_df["compounds_screened"].apply(
+            lambda res: int_response_value_types(res, ["compound_cid"])
+        )
+    merged_df.reset_index(drop=True, inplace=True)
+
+    # Metdata details
+    # Get the current date and time
+    current_date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    # Calculate the time elapsed
+    time_elapsed = str(end_time - start_time)
+
+    # Add the datasource, query, query time, and the date to metadata
+    molmedb_metadata = {
+        "datasource": "PubChem",
+        "query": {
+            "size": len(protein_list_str),
+            "time": time_elapsed,
+            "date": current_date,
+            "url": "https://idsm.elixir-czech.cz/sparql/endpoint/idsm",
+        },
+    }
+
+    return merged_df, molmedb_metadata
+
+
+def int_response_value_types(resp_list: list, key_list: list):
+    """Change values in response dictionaries to int to stay consistent with other Annotators.
+
+    :param: resp_list: list of response dictionaries.
+    :param: key_list: list of keys to change to int.
+    :returns: resp_list with int values in response dictionaries on keys in key_list.
+    """
+    for r in resp_list:
+        for k in key_list:
+            try:
+                r[k] = int(r[k])
+            except ValueError:
+                continue
+    return resp_list

--- a/src/pyBiodatafuse/annotators/queries/pubchem-proteins-screend-molecule.rq
+++ b/src/pyBiodatafuse/annotators/queries/pubchem-proteins-screend-molecule.rq
@@ -1,0 +1,56 @@
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX cheminf: <http://semanticscience.org/resource/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX cito: <http://purl.org/spar/cito/>
+PREFIX vocab: <http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX bao: <http://www.bioassayontology.org/bao#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX pubchem: <http://rdf.ncbi.nlm.nih.gov/pubchem/>
+
+SELECT DISTINCT ?upProt ?assay_type ?outcome ?compound_cid ?ref_cit ?compound_name ?SMILES ?InChI WHERE {
+  	#consider only ednpoints with = value or implicitly equal
+	VALUES ?bannedQualifier {obo:GENEPIO_0001002 obo:GENEPIO_0001003 obo:GENEPIO_0001005 obo:GENEPIO_0001006 }
+    
+	VALUES ?upProt {$protein_list}
+    
+	GRAPH pubchem:protein {
+		?prot skos:closeMatch ?upProt
+  	}
+  	GRAPH pubchem:measuregroup{
+    	?mg obo:RO_0000057 ?prot;
+  	}
+  	FILTER NOT EXISTS {
+    	?mg obo:RO_0000057 ?target 
+  		FILTER(?prot != ?target)
+  	}
+  
+  	?mg obo:OBI_0000299 ?ep ;
+		#only confirmatory assay
+    	^bao:BAO_0000209 [bao:BAO_0000540 ?b] .
+  
+  	?ep rdf:type ?assay_type ;
+		vocab:PubChemAssayOutcome ?outcome ;
+  		obo:IAO_0000136 [cheminf:CHEMINF_000477 ?compound_cid] ;
+                     
+	FILTER NOT EXISTS {?ep vocab:hasQualifier ?bannedQualifier}
+  
+	OPTIONAL {
+    	#identifiers badly defined by PubChem, consider citation only
+    	?ep cito:citesAsDataSource [dcterms:bibliographicCitation ?ref_cit].
+  	}
+	OPTIONAL{
+    	?compound_cid rdfs:label ?compound_name
+  	}
+  	OPTIONAL{
+    	?compound_cid sio:SIO_000008 [ rdf:type sio:CHEMINF_000376;
+                           sio:SIO_000300 ?SMILES]
+  	}
+	OPTIONAL{
+    	?compound_cid sio:SIO_000008 [ rdf:type sio:CHEMINF_000396;
+                           sio:SIO_000300 ?InChI]
+  	}
+  	#other Compound mappings badly defined ind PubChem
+}

--- a/src/pyBiodatafuse/annotators/queries/pubchem-proteins-screend-molecule.rq
+++ b/src/pyBiodatafuse/annotators/queries/pubchem-proteins-screend-molecule.rq
@@ -10,21 +10,18 @@ PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX pubchem: <http://rdf.ncbi.nlm.nih.gov/pubchem/>
 
-SELECT DISTINCT ?upProt ?assay_type ?outcome ?compound_cid ?ref_cit ?compound_name ?SMILES ?InChI WHERE {
+SELECT DISTINCT ?upProt ?assay_type ?outcome ?compound_cid ?ref_cit ?compound_name ?SMILES ?InChI (COUNT(DISTINCT ?target) AS ?target_count) WHERE {
   	#consider only ednpoints with = value or implicitly equal
 	VALUES ?bannedQualifier {obo:GENEPIO_0001002 obo:GENEPIO_0001003 obo:GENEPIO_0001005 obo:GENEPIO_0001006 }
-    
+    VALUES ?outcome {vocab:active vocab:inactive}
+	VALUES ?type {bao:BAO_0000034 bao:BAO_0000186 bao:BAO_0000187 bao:BAO_0000188 bao:BAO_0000190 bao:BAO_0000192 bao:BAO_0002146}
 	VALUES ?upProt {$protein_list}
-    
 	GRAPH pubchem:protein {
 		?prot skos:closeMatch ?upProt
   	}
   	GRAPH pubchem:measuregroup{
     	?mg obo:RO_0000057 ?prot;
-  	}
-  	FILTER NOT EXISTS {
-    	?mg obo:RO_0000057 ?target 
-  		FILTER(?prot != ?target)
+    		obo:RO_0000057 ?target
   	}
   
   	?mg obo:OBI_0000299 ?ep ;
@@ -53,4 +50,4 @@ SELECT DISTINCT ?upProt ?assay_type ?outcome ?compound_cid ?ref_cit ?compound_na
                            sio:SIO_000300 ?InChI]
   	}
   	#other Compound mappings badly defined ind PubChem
-}
+} GROUP BY ?upProt ?assay_type ?outcome ?compound_cid ?ref_cit ?compound_name ?SMILES ?InChI

--- a/tests/annotators/test_pubchem.py
+++ b/tests/annotators/test_pubchem.py
@@ -13,7 +13,7 @@ from pyBiodatafuse.annotators.pubchem import get_protein_molecule_screened
 
 
 @patch("pyBiodatafuse.annotators.pubchem.SPARQLWrapper.queryAndConvert")
-def get_protein_molecule_screened(mock_sparql_request, bridgedb_dataframe):
+def test_get_protein_molecule_screened(mock_sparql_request, bridgedb_dataframe):
     """Test the get_protein_molecule_screened."""
     mock_sparql_request.side_effect = [
         {

--- a/tests/annotators/test_pubchem.py
+++ b/tests/annotators/test_pubchem.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for the WikiPathways annotator."""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from numpy import nan
+
+from pyBiodatafuse.annotators.pubchem import get_protein_molecule_screened
+
+
+@patch("pyBiodatafuse.annotators.pubchem.SPARQLWrapper.queryAndConvert")
+def get_protein_molecule_screened(mock_sparql_request, bridgedb_dataframe):
+    """Test the get_protein_molecule_screened."""
+    mock_sparql_request.side_effect = [
+        {
+            "head": {
+                "vars": [
+                    "upProt",
+                    "assay_type",
+                    "outcome",
+                    "compound_cid",
+                    "ref_cit",
+                    "compound_name",
+                    "SMILES",
+                    "InChI",
+                ]
+            },
+            "results": {
+                "bindings": [
+                    {
+                        "upProt": {
+                            "type": "uri",
+                            "value": "http://purl.uniprot.org/uniprot/P46098",
+                        },
+                        "assay_type": {
+                            "type": "uri",
+                            "value": "http://www.bioassayontology.org/bao#BAO_0000192",
+                        },
+                        "outcome": {
+                            "type": "uri",
+                            "value": "http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#active",
+                        },
+                        "compound_cid": {
+                            "type": "uri",
+                            "value": "http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID9911844",
+                        },
+                        "ref_cit": {
+                            "type": "literal",
+                            "value": "Kikuchi C, Suzuki H, Hiranuma T, Koyama M.",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#string",
+                        },
+                        "compound_name": {
+                            "type": "literal",
+                            "value": "DR-4485 free base",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#string",
+                        },
+                        "SMILES": {
+                            "type": "literal",
+                            "value": "C1CC2=C(C=CC3=C2C(C1)(C(=O)N3)CCCCN4CCC(=CC4)C5=CC=C(C=C5)Cl)Cl",
+                            "xml:lang": "en",
+                        },
+                        "InChI": {
+                            "type": "literal",
+                            "value": "InChI=1S/C26H28Cl2N2O/c27",
+                            "xml:lang": "en",
+                        },
+                    },
+                    {
+                        "upProt": {
+                            "type": "uri",
+                            "value": "http://purl.uniprot.org/uniprot/P00533",
+                        },
+                        "assay_type": {
+                            "type": "uri",
+                            "value": "http://www.bioassayontology.org/bao#BAO_0000186",
+                        },
+                        "outcome": {
+                            "type": "uri",
+                            "value": "http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#inconclusive",
+                        },
+                        "compound_cid": {
+                            "type": "uri",
+                            "value": "http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID5151543",
+                        },
+                        "compound_name": {
+                            "type": "literal",
+                            "value": "1-(4-Methylpiperazin-1-yl)anthra-9,10-quinone",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#string",
+                        },
+                        "SMILES": {
+                            "type": "literal",
+                            "value": "CN1CCN(CC1)C2=CC=CC3=C2C(=O)C4=CC=CC=C4C3=O",
+                            "xml:lang": "en",
+                        },
+                        "InChI": {
+                            "type": "literal",
+                            "value": "InChI=1S/C19H18N2O2/c1",
+                            "xml:lang": "en",
+                        },
+                    },
+                    {
+                        "upProt": {
+                            "type": "uri",
+                            "value": "http://purl.uniprot.org/uniprot/P00533",
+                        },
+                        "assay_type": {
+                            "type": "uri",
+                            "value": "http://www.bioassayontology.org/bao#BAO_0000186",
+                        },
+                        "outcome": {
+                            "type": "uri",
+                            "value": "http://rdf.ncbi.nlm.nih.gov/pubchem/vocabulary#inconclusive",
+                        },
+                        "compound_cid": {
+                            "type": "uri",
+                            "value": "http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID6706",
+                        },
+                        "compound_name": {
+                            "type": "literal",
+                            "value": "1-(Methylamino)anthraquinone",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#string",
+                        },
+                        "SMILES": {
+                            "type": "literal",
+                            "value": "CNC1=CC=CC2=C1C(=O)C3=CC=CC=C3C2=O",
+                            "xml:lang": "en",
+                        },
+                        "InChI": {
+                            "type": "literal",
+                            "value": "InChI=1S/C15H11NO2/c1",
+                            "xml:lang": "en",
+                        },
+                    },
+                ]
+            },
+        }
+    ]
+
+    obtained_data, metadata = get_protein_molecule_screened(bridgedb_dataframe)
+
+    expected_data = pd.Series(
+        [
+            [
+                {
+                    "assay_type": "AC50",
+                    "outcome": "inconclusive",
+                    "compound_cid": 5151543,
+                    "compound_name": "1-(4-Methylpiperazin-1-yl)anthra-9,10-quinone",
+                    "SMILES": "CN1CCN(CC1)C2=CC=CC3=C2C(=O)C4=CC=CC=C4C3=O",
+                    "InChI": "InChI=1S/C19H18N2O2/c1",
+                    "ref_cit": nan,
+                },
+                {
+                    "assay_type": "AC50",
+                    "outcome": "inconclusive",
+                    "compound_cid": 6706,
+                    "compound_name": "1-(Methylamino)anthraquinone",
+                    "SMILES": "CNC1=CC=CC2=C1C(=O)C3=CC=CC=C3C2=O",
+                    "InChI": "InChI=1S/C15H11NO2/c1",
+                    "ref_cit": nan,
+                },
+            ],
+            [
+                {
+                    "assay_type": "Ki",
+                    "outcome": "active",
+                    "compound_cid": 9911844,
+                    "compound_name": "DR-4485 free base",
+                    "SMILES": "C1CC2=C(C=CC3=C2C(C1)(C(=O)N3)CCCCN4CCC(=CC4)C5=CC=C(C=C5)Cl)Cl",
+                    "InChI": "InChI=1S/C26H28Cl2N2O/c27",
+                    "ref_cit": "Kikuchi C, Suzuki H, Hiranuma T, Koyama M.",
+                }
+            ],
+        ]
+    )
+    expected_data.name = "compounds_screened"
+
+    pd.testing.assert_series_equal(obtained_data["compounds_screened"], expected_data)
+
+
+@pytest.fixture(scope="module")
+def bridgedb_dataframe():
+    """Reusable sample Pandas DataFrame to be used as input for the tests."""
+    return pd.DataFrame(
+        {
+            "identifier": ["EGFR", "EGFR", "EGFR", "HTR3A", "HTR3A"],
+            "identifier.source": ["HGNC", "HGNC", "HGNC", "HGNC", "HGNC"],
+            "target": ["C9JYS6", "P00533", "Q504U8", "A0A0B4J205", "P46098"],
+            "target.source": [
+                "Uniprot-TrEMBL",
+                "Uniprot-TrEMBL",
+                "Uniprot-TrEMBL",
+                "Uniprot-TrEMBL",
+                "Uniprot-TrEMBL",
+            ],
+        }
+    )

--- a/tests/annotators/test_pubchem.py
+++ b/tests/annotators/test_pubchem.py
@@ -68,6 +68,11 @@ def test_get_protein_molecule_screened(mock_sparql_request, bridgedb_dataframe):
                             "value": "InChI=1S/C26H28Cl2N2O/c27",
                             "xml:lang": "en",
                         },
+                        "target_count": {
+                            "type": "literal",
+                            "value": "1",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+                        },
                     },
                     {
                         "upProt": {
@@ -101,6 +106,11 @@ def test_get_protein_molecule_screened(mock_sparql_request, bridgedb_dataframe):
                             "value": "InChI=1S/C19H18N2O2/c1",
                             "xml:lang": "en",
                         },
+                        "target_count": {
+                            "type": "literal",
+                            "value": "1",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+                        },
                     },
                     {
                         "upProt": {
@@ -133,6 +143,11 @@ def test_get_protein_molecule_screened(mock_sparql_request, bridgedb_dataframe):
                             "type": "literal",
                             "value": "InChI=1S/C15H11NO2/c1",
                             "xml:lang": "en",
+                        },
+                        "target_count": {
+                            "type": "literal",
+                            "value": "1",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#integer",
                         },
                     },
                 ]


### PR DESCRIPTION
Pubchem annotator added.
Uses Uniprot ids for assays on proteins. Returns compund CID, name, SMILES and InChI, assay type, outcome and citation to reference.
Might need a bit of a tinkering later.

Pubchem annotator unittest added.