### PR TITLE
Add merge_node function for nodes with same label

### DIFF
--- a/examples/gene_to_graph_workflow.ipynb
+++ b/examples/gene_to_graph_workflow.ipynb
@@ -87,37 +87,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\Tooba\\AppData\\Local\\Temp\\ipykernel_18404\\2222538723.py:1: UserWarning: Wikidata SPARQL endpoint is not available. Unable to retrieve data.\n",
-      "  wikidata.get_gene_literature(bridgedb_df=bridgdb_df)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(Empty DataFrame\n",
-       " Columns: []\n",
-       " Index: [],\n",
-       " {})"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "wikidata.get_gene_literature(bridgedb_df=bridgdb_df)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -372,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +433,7 @@
        "4  [{'anatomical_entity_id': 'UBERON_0000178', 'a...  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -476,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -486,12 +455,12 @@
        "  'anatomical_entity_name': 'blood',\n",
        "  'developmental_stage_id': 'UBERON_0000104',\n",
        "  'developmental_stage_name': 'life cycle',\n",
-       "  'expression_level': 80.2387,\n",
+       "  'expression_level': 80.23869999999998,\n",
        "  'confidence_level_id': 'CIO_0000029',\n",
        "  'confidence_level_name': 'high confidence level'}]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,538 +473,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Disease annotatation from DisGeNet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>identifier</th>\n",
-       "      <th>identifier.source</th>\n",
-       "      <th>target</th>\n",
-       "      <th>target.source</th>\n",
-       "      <th>DisGeNET</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AHR</td>\n",
-       "      <td>HGNC</td>\n",
-       "      <td>196</td>\n",
-       "      <td>NCBI Gene</td>\n",
-       "      <td>[{'disease_id': 'umls:C2350344', 'disease_name...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>CHRNG</td>\n",
-       "      <td>HGNC</td>\n",
-       "      <td>1146</td>\n",
-       "      <td>NCBI Gene</td>\n",
-       "      <td>[{'disease_id': 'umls:C0751882', 'disease_name...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>DMD</td>\n",
-       "      <td>HGNC</td>\n",
-       "      <td>1756</td>\n",
-       "      <td>NCBI Gene</td>\n",
-       "      <td>[{'disease_id': 'umls:C0340427', 'disease_name...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>HTR3A</td>\n",
-       "      <td>HGNC</td>\n",
-       "      <td>3359</td>\n",
-       "      <td>NCBI Gene</td>\n",
-       "      <td>[{'disease_id': 'umls:C0001973', 'disease_name...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>SCN4A</td>\n",
-       "      <td>HGNC</td>\n",
-       "      <td>6329</td>\n",
-       "      <td>NCBI Gene</td>\n",
-       "      <td>[{'disease_id': 'umls:C0751882', 'disease_name...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  identifier identifier.source target target.source  \\\n",
-       "0        AHR              HGNC    196     NCBI Gene   \n",
-       "1      CHRNG              HGNC   1146     NCBI Gene   \n",
-       "2        DMD              HGNC   1756     NCBI Gene   \n",
-       "3      HTR3A              HGNC   3359     NCBI Gene   \n",
-       "4      SCN4A              HGNC   6329     NCBI Gene   \n",
-       "\n",
-       "                                            DisGeNET  \n",
-       "0  [{'disease_id': 'umls:C2350344', 'disease_name...  \n",
-       "1  [{'disease_id': 'umls:C0751882', 'disease_name...  \n",
-       "2  [{'disease_id': 'umls:C0340427', 'disease_name...  \n",
-       "3  [{'disease_id': 'umls:C0001973', 'disease_name...  \n",
-       "4  [{'disease_id': 'umls:C0751882', 'disease_name...  "
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "disgenet_df, disgenet_metadata = disgenet.get_gene_disease(bridgedb_df=bridgdb_df)\n",
-    "disgenet_df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'disease_id': 'umls:C2350344',\n",
-       "  'disease_name': 'Chronic Lung Injury',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0004943',\n",
-       "  'disease_name': 'Behcet Syndrome',\n",
-       "  'score': 0.32,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0376358',\n",
-       "  'disease_name': 'Malignant neoplasm of prostate',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0700501',\n",
-       "  'disease_name': 'Congenital nystagmus',\n",
-       "  'score': 0.5,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0993582',\n",
-       "  'disease_name': 'Arthritis, Experimental',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0153619',\n",
-       "  'disease_name': 'Malignant neoplasm of ureter',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0027540',\n",
-       "  'disease_name': 'Necrosis',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0035334',\n",
-       "  'disease_name': 'Retinitis Pigmentosa',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'ORPHANET'},\n",
-       " {'disease_id': 'umls:C0239946',\n",
-       "  'disease_name': 'Fibrosis, Liver',\n",
-       "  'score': 0.32,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0887800',\n",
-       "  'disease_name': 'Psychogenic Inversion of Circadian Rhythm',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C4277682',\n",
-       "  'disease_name': 'Chemical and Drug Induced Liver Injury',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0023895',\n",
-       "  'disease_name': 'Liver diseases',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0025517',\n",
-       "  'disease_name': 'Metabolic Diseases',\n",
-       "  'score': 0.35,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0033578',\n",
-       "  'disease_name': 'Prostatic Neoplasms',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C1458155',\n",
-       "  'disease_name': 'Mammary Neoplasms',\n",
-       "  'score': 0.39,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0019209',\n",
-       "  'disease_name': 'Hepatomegaly',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0020564',\n",
-       "  'disease_name': 'Hypertrophy',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0021368',\n",
-       "  'disease_name': 'Inflammation',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0027626',\n",
-       "  'disease_name': 'Neoplasm Invasiveness',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0920563',\n",
-       "  'disease_name': 'Insulin Sensitivity',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0028754',\n",
-       "  'disease_name': 'Obesity',\n",
-       "  'score': 0.45,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0149721',\n",
-       "  'disease_name': 'Left Ventricular Hypertrophy',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0346647',\n",
-       "  'disease_name': 'Malignant neoplasm of pancreas',\n",
-       "  'score': 0.32,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C1257931',\n",
-       "  'disease_name': 'Mammary Neoplasms, Human',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0005683',\n",
-       "  'disease_name': 'Urinary Bladder Calculi (disorder)',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0009319',\n",
-       "  'disease_name': 'Colitis',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0019193',\n",
-       "  'disease_name': 'Hepatitis, Toxic',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C1262760',\n",
-       "  'disease_name': 'Hepatitis, Drug-Induced',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0376384',\n",
-       "  'disease_name': 'Nicotine Use Disorder',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0598784',\n",
-       "  'disease_name': 'Dyslipoproteinemias',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0080203',\n",
-       "  'disease_name': 'Tachyarrhythmia',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C4704874',\n",
-       "  'disease_name': 'Mammary Carcinoma, Human',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0345904',\n",
-       "  'disease_name': 'Malignant neoplasm of liver',\n",
-       "  'score': 0.34,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C3241937',\n",
-       "  'disease_name': 'Nonalcoholic Steatohepatitis',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C4552766',\n",
-       "  'disease_name': 'Miscarriage',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0005974',\n",
-       "  'disease_name': 'Bone Resorption',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0027659',\n",
-       "  'disease_name': 'Neoplasms, Experimental',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0162351',\n",
-       "  'disease_name': 'Contact hypersensitivity',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0162834',\n",
-       "  'disease_name': 'Hyperpigmentation',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0242706',\n",
-       "  'disease_name': 'Hyperoxia',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0333641',\n",
-       "  'disease_name': 'Atrophic',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0559470',\n",
-       "  'disease_name': 'Allergy to peanuts',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0003865',\n",
-       "  'disease_name': 'Arthritis, Adjuvant-Induced',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0971858',\n",
-       "  'disease_name': 'Arthritis, Collagen-Induced',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C4279912',\n",
-       "  'disease_name': 'Chemically-Induced Liver Toxicity',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0027651',\n",
-       "  'disease_name': 'Neoplasms',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0917731',\n",
-       "  'disease_name': 'Male sterility',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C1563937',\n",
-       "  'disease_name': 'Atherogenesis',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C2673809',\n",
-       "  'disease_name': 'Infantile nystagmus',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'GENOMICS_ENGLAND'},\n",
-       " {'disease_id': 'umls:C0887898',\n",
-       "  'disease_name': 'Experimental Lung Inflammation',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0006826',\n",
-       "  'disease_name': 'Malignant Neoplasms',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C3830362',\n",
-       "  'disease_name': 'Early Pregnancy Loss',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0006142',\n",
-       "  'disease_name': 'Malignant neoplasm of breast',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0032300',\n",
-       "  'disease_name': 'Lobar Pneumonia',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C3714636',\n",
-       "  'disease_name': 'Pneumonitis',\n",
-       "  'score': 0.33,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0003873',\n",
-       "  'disease_name': 'Rheumatoid Arthritis',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0024623',\n",
-       "  'disease_name': 'Malignant neoplasm of stomach',\n",
-       "  'score': 0.36,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C1708349',\n",
-       "  'disease_name': 'Hereditary Diffuse Gastric Cancer',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C2931037',\n",
-       "  'disease_name': 'Pancreatic cancer, adult',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0028043',\n",
-       "  'disease_name': 'Nicotine Dependence',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0030297',\n",
-       "  'disease_name': 'Pancreatic Neoplasm',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0813142',\n",
-       "  'disease_name': 'Circadian Rhythm Disorders',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0018273',\n",
-       "  'disease_name': 'Growth Disorders',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0018798',\n",
-       "  'disease_name': 'Congenital Heart Defects',\n",
-       "  'score': 0.32,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0020538',\n",
-       "  'disease_name': 'Hypertensive disease',\n",
-       "  'score': 0.36,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0023903',\n",
-       "  'disease_name': 'Liver neoplasms',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0037997',\n",
-       "  'disease_name': 'Splenic Diseases',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0038356',\n",
-       "  'disease_name': 'Stomach Neoplasms',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0041955',\n",
-       "  'disease_name': 'Ureteral Neoplasms',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0042373',\n",
-       "  'disease_name': 'Vascular Diseases',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0236811',\n",
-       "  'disease_name': 'Chronobiology Disorders',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0242339',\n",
-       "  'disease_name': 'Dyslipidemias',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0000786',\n",
-       "  'disease_name': 'Spontaneous abortion',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0005612',\n",
-       "  'disease_name': 'Birth Weight',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0018800',\n",
-       "  'disease_name': 'Cardiomegaly',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0020578',\n",
-       "  'disease_name': 'Hyperventilation',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0021364',\n",
-       "  'disease_name': 'Male infertility',\n",
-       "  'score': 0.34,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0021655',\n",
-       "  'disease_name': 'Insulin Resistance',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0027627',\n",
-       "  'disease_name': 'Neoplasm Metastasis',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0038002',\n",
-       "  'disease_name': 'Splenomegaly',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0039231',\n",
-       "  'disease_name': 'Tachycardia',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0043094',\n",
-       "  'disease_name': 'Weight Gain',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0086565',\n",
-       "  'disease_name': 'Liver Dysfunction',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0848676',\n",
-       "  'disease_name': 'Subfertility, Male',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0860207',\n",
-       "  'disease_name': 'Drug-Induced Liver Disease',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C1383860',\n",
-       "  'disease_name': 'Cardiac Hypertrophy',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0004153',\n",
-       "  'disease_name': 'Atherosclerosis',\n",
-       "  'score': 0.35,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0011616',\n",
-       "  'disease_name': 'Contact Dermatitis',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0023890',\n",
-       "  'disease_name': 'Liver Cirrhosis',\n",
-       "  'score': 0.31,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0032285',\n",
-       "  'disease_name': 'Pneumonia',\n",
-       "  'score': 0.33,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0040332',\n",
-       "  'disease_name': 'Tobacco Dependence',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0152013',\n",
-       "  'disease_name': 'Adenocarcinoma of lung (disorder)',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0273115',\n",
-       "  'disease_name': 'Lung Injury',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0678222',\n",
-       "  'disease_name': 'Breast Carcinoma',\n",
-       "  'score': 0.4,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C3658290',\n",
-       "  'disease_name': 'Drug-Induced Acute Liver Injury',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0000822',\n",
-       "  'disease_name': 'Abortion, Tubal',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0086692',\n",
-       "  'disease_name': 'Benign Neoplasm',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0400966',\n",
-       "  'disease_name': 'Non-alcoholic Fatty Liver Disease',\n",
-       "  'score': 0.33,\n",
-       "  'evidence_source': 'CTD_human'},\n",
-       " {'disease_id': 'umls:C0037116',\n",
-       "  'disease_name': 'Silicosis',\n",
-       "  'score': 0.3,\n",
-       "  'evidence_source': 'CTD_human'}]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "disgenet_df[DISGENET][0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Disease annotation from OpenTargets"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -1097,7 +540,7 @@
        "      <td>HGNC</td>\n",
        "      <td>ENSG00000166736</td>\n",
        "      <td>Ensembl</td>\n",
-       "      <td>[{'disease_id': 'umls:C0011206', 'disease_name...</td>\n",
+       "      <td>[{'disease_id': 'EFO_0003843', 'disease_name':...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1105,7 +548,7 @@
        "      <td>HGNC</td>\n",
        "      <td>ENSG00000007314</td>\n",
        "      <td>Ensembl</td>\n",
-       "      <td>[{'disease_id': 'umls:C0037011', 'disease_name...</td>\n",
+       "      <td>[{'disease_id': 'EFO_0000432', 'disease_name':...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1123,11 +566,11 @@
        "0  [{'disease_id': 'umls:C0033860', 'disease_name...  \n",
        "1  [{'disease_id': 'umls:C0085631', 'disease_name...  \n",
        "2  [{'disease_id': 'umls:C0013264', 'disease_name...  \n",
-       "3  [{'disease_id': 'umls:C0011206', 'disease_name...  \n",
-       "4  [{'disease_id': 'umls:C0037011', 'disease_name...  "
+       "3  [{'disease_id': 'EFO_0003843', 'disease_name':...  \n",
+       "4  [{'disease_id': 'EFO_0000432', 'disease_name':...  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1141,7 +584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1152,10 +595,13 @@
        "  'therapeutic_areas': 'OTAR_0000018:genetic, familial or congenital disease, EFO_0000540:immune system disease, EFO_0010285:integumentary system disease'},\n",
        " {'disease_id': 'EFO_0000274',\n",
        "  'disease_name': 'atopic eczema',\n",
+       "  'therapeutic_areas': 'OTAR_0000018:genetic, familial or congenital disease, EFO_0000540:immune system disease, EFO_0010285:integumentary system disease'},\n",
+       " {'disease_id': 'MONDO_0011292',\n",
+       "  'disease_name': 'dermatitis, atopic',\n",
        "  'therapeutic_areas': 'OTAR_0000018:genetic, familial or congenital disease, EFO_0000540:immune system disease, EFO_0010285:integumentary system disease'}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1173,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1265,7 +711,7 @@
        "4  [{'pathway_id': nan, 'pathway_label': nan, 'pa...  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1279,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -1290,7 +736,7 @@
        "  'pathway_gene_count': 45.0}]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1308,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1346,7 +792,7 @@
        "      <td>HGNC</td>\n",
        "      <td>196</td>\n",
        "      <td>NCBI Gene</td>\n",
-       "      <td>[{'pathway_id': 'WP3869', 'pathway_label': 'Ca...</td>\n",
+       "      <td>[{'pathway_id': 'WP5044', 'pathway_label': 'Ky...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1393,14 +839,14 @@
        "4      SCN4A              HGNC   6329     NCBI Gene   \n",
        "\n",
        "                                        WikiPathways  \n",
-       "0  [{'pathway_id': 'WP3869', 'pathway_label': 'Ca...  \n",
+       "0  [{'pathway_id': 'WP5044', 'pathway_label': 'Ky...  \n",
        "1  [{'pathway_id': nan, 'pathway_label': nan, 'pa...  \n",
        "2  [{'pathway_id': 'WP2858', 'pathway_label': 'Ec...  \n",
        "3  [{'pathway_id': 'WP706', 'pathway_label': 'Sud...  \n",
        "4  [{'pathway_id': nan, 'pathway_label': nan, 'pa...  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1412,36 +858,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[{'pathway_id': 'WP3869',\n",
+       "[{'pathway_id': 'WP5044',\n",
+       "  'pathway_label': 'Kynurenine pathway and links to cell senescence',\n",
+       "  'pathway_gene_count': 10.0},\n",
+       " {'pathway_id': 'WP3893',\n",
+       "  'pathway_label': 'Development and heterogeneity of the ILC family',\n",
+       "  'pathway_gene_count': 32.0},\n",
+       " {'pathway_id': 'WP3869',\n",
        "  'pathway_label': 'Cannabinoid receptor signaling',\n",
        "  'pathway_gene_count': 31.0},\n",
        " {'pathway_id': 'WP4673',\n",
        "  'pathway_label': 'Male infertility',\n",
        "  'pathway_gene_count': 145.0},\n",
-       " {'pathway_id': 'WP5115',\n",
-       "  'pathway_label': 'Network map of SARS-CoV-2 signaling pathway',\n",
-       "  'pathway_gene_count': 251.0},\n",
+       " {'pathway_id': 'WP2586',\n",
+       "  'pathway_label': 'Aryl hydrocarbon receptor pathway',\n",
+       "  'pathway_gene_count': 45.0},\n",
        " {'pathway_id': 'WP236',\n",
        "  'pathway_label': 'Adipogenesis',\n",
        "  'pathway_gene_count': 131.0},\n",
-       " {'pathway_id': 'WP2586',\n",
-       "  'pathway_label': 'Aryl hydrocarbon receptor pathway',\n",
-       "  'pathway_gene_count': 44.0},\n",
        " {'pathway_id': 'WP2873',\n",
        "  'pathway_label': 'Aryl hydrocarbon receptor pathway',\n",
        "  'pathway_gene_count': 46.0},\n",
        " {'pathway_id': 'WP5088',\n",
        "  'pathway_label': 'Prostaglandin signaling',\n",
        "  'pathway_gene_count': 31.0},\n",
-       " {'pathway_id': 'WP3893',\n",
-       "  'pathway_label': 'Development and heterogeneity of the ILC family',\n",
-       "  'pathway_gene_count': 32.0},\n",
+       " {'pathway_id': 'WP5115',\n",
+       "  'pathway_label': 'Network map of SARS-CoV-2 signaling',\n",
+       "  'pathway_gene_count': 251.0},\n",
        " {'pathway_id': 'WP465',\n",
        "  'pathway_label': 'Tryptophan metabolism',\n",
        "  'pathway_gene_count': 32.0},\n",
@@ -1451,15 +900,12 @@
        " {'pathway_id': 'WP2882',\n",
        "  'pathway_label': 'Nuclear receptors meta-pathway',\n",
        "  'pathway_gene_count': 318.0},\n",
-       " {'pathway_id': 'WP5044',\n",
-       "  'pathway_label': 'Kynurenine pathway and links to cell senescence',\n",
-       "  'pathway_gene_count': 9.0},\n",
        " {'pathway_id': 'WP3594',\n",
        "  'pathway_label': 'Circadian rhythm genes',\n",
        "  'pathway_gene_count': 209.0}]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1477,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1569,7 +1015,7 @@
        "4  [{'pathway_label': 'Phase 0 - rapid depolarisa...  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1583,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1599,7 +1045,7 @@
        "  'pathway_id': 'R-HSA-8937144'}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1617,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1687,7 +1133,7 @@
        "      <td>HGNC</td>\n",
        "      <td>ENSG00000007314</td>\n",
        "      <td>Ensembl</td>\n",
-       "      <td>[{'go_id': 'GO:0019228', 'go_name': 'neuronal ...</td>\n",
+       "      <td>[{'go_id': 'GO:0035725', 'go_name': 'sodium io...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1706,10 +1152,10 @@
        "1  [{'go_id': 'GO:0015464', 'go_name': 'acetylcho...  \n",
        "2  [{'go_id': 'GO:0016010', 'go_name': 'dystrophi...  \n",
        "3  [{'go_id': 'GO:1904602', 'go_name': 'serotonin...  \n",
-       "4  [{'go_id': 'GO:0019228', 'go_name': 'neuronal ...  "
+       "4  [{'go_id': 'GO:0035725', 'go_name': 'sodium io...  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1721,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1743,7 +1189,6 @@
        " {'go_id': 'GO:0000976',\n",
        "  'go_name': 'transcription cis-regulatory region binding',\n",
        "  'go_type': 'F'},\n",
-       " {'go_id': 'GO:0007049', 'go_name': 'cell cycle', 'go_type': 'P'},\n",
        " {'go_id': 'GO:0005829', 'go_name': 'cytosol', 'go_type': 'C'},\n",
        " {'go_id': 'GO:0030888',\n",
        "  'go_name': 'regulation of B cell proliferation',\n",
@@ -1760,6 +1205,9 @@
        "  'go_type': 'P'},\n",
        " {'go_id': 'GO:0071320',\n",
        "  'go_name': 'cellular response to cAMP',\n",
+       "  'go_type': 'P'},\n",
+       " {'go_id': 'GO:0030522',\n",
+       "  'go_name': 'intracellular receptor signaling pathway',\n",
        "  'go_type': 'P'},\n",
        " {'go_id': 'GO:0000987',\n",
        "  'go_name': 'cis-regulatory region sequence-specific DNA binding',\n",
@@ -1844,15 +1292,12 @@
        " {'go_id': 'GO:0006355',\n",
        "  'go_name': 'regulation of DNA-templated transcription',\n",
        "  'go_type': 'P'},\n",
-       " {'go_id': 'GO:0030522',\n",
-       "  'go_name': 'intracellular receptor signaling pathway',\n",
-       "  'go_type': 'P'},\n",
        " {'go_id': 'GO:0002841',\n",
        "  'go_name': 'negative regulation of T cell mediated immune response to tumor cell',\n",
        "  'go_type': 'P'}]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1870,7 +1315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1962,7 +1407,7 @@
        "4  [{'location_id': 'SL-0039', 'location': 'Cell ...  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1974,7 +1419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1994,7 +1439,7 @@
        "  'subcellular_location': 'Nucleoplasm'}]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2012,7 +1457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -2096,7 +1541,7 @@
        "      <td>HGNC</td>\n",
        "      <td>ENSG00000007314</td>\n",
        "      <td>Ensembl</td>\n",
-       "      <td>[{'chembl_id': 'CHEMBL1098', 'drugbank_id': 'D...</td>\n",
+       "      <td>[{'chembl_id': 'CHEMBL1077896', 'drugbank_id':...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2115,10 +1560,10 @@
        "1  [{'chembl_id': 'CHEMBL1200641', 'drugbank_id':...  \n",
        "2  [{'chembl_id': 'CHEMBL2108278', 'drugbank_id':...  \n",
        "3  [{'chembl_id': 'CHEMBL56564', 'drugbank_id': '...  \n",
-       "4  [{'chembl_id': 'CHEMBL1098', 'drugbank_id': 'D...  "
+       "4  [{'chembl_id': 'CHEMBL1077896', 'drugbank_id':...  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2132,7 +1577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -2148,7 +1593,7 @@
        "  'adverse_effect': None}]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2166,7 +1611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -2258,7 +1703,7 @@
        "4  [{'compound_name': '3-phenyl-1h-pyrazole', 'In...  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2270,7 +1715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -2284,11 +1729,10 @@
        "  'source_doi': nan,\n",
        "  'source_pmid': nan,\n",
        "  'chebi_id': nan,\n",
-       "  'pdb_ligand_id': nan,\n",
        "  'drugbank_id': nan}]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2306,7 +1750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -2398,7 +1842,7 @@
        "4  [{'pubchem_assay_id': nan, 'assay_type': nan, ...  "
       ]
      },
-     "execution_count": 26,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2412,7 +1856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -2427,7 +1871,7 @@
        "  'InChI': nan}]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2445,7 +1889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -2537,7 +1981,7 @@
        "4                                                 []  "
       ]
      },
-     "execution_count": 28,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2549,7 +1993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -2558,7 +2002,7 @@
        "[{'stringdb_link_to': 'SCN4A', 'Ensembl': 'ENSP00000396320', 'score': 0.454}]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2583,7 +2027,6 @@
     "combined_df = combine_sources(\n",
     "    [\n",
     "        bgee_df,\n",
-    "        disgenet_df,\n",
     "        minerva_df,\n",
     "        wikipathways_df,\n",
     "        reactome_process_df,\n",
@@ -2629,7 +2072,6 @@
        "      <th>target</th>\n",
        "      <th>target.source</th>\n",
        "      <th>Bgee</th>\n",
-       "      <th>DisGeNET</th>\n",
        "      <th>MINERVA</th>\n",
        "      <th>WikiPathways</th>\n",
        "      <th>OpenTargets_Reactome</th>\n",
@@ -2650,9 +2092,8 @@
        "      <td>ENSG00000106546</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C2350344', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': 953.0, 'pathway_label': 'Kynur...</td>\n",
-       "      <td>[{'pathway_id': 'WP3869', 'pathway_label': 'Ca...</td>\n",
+       "      <td>[{'pathway_id': 'WP5044', 'pathway_label': 'Ky...</td>\n",
        "      <td>[{'pathway_label': 'Endogenous sterols', 'path...</td>\n",
        "      <td>[{'go_id': 'GO:0005667', 'go_name': 'transcrip...</td>\n",
        "      <td>[{'location_id': 'SL-0086', 'location': 'Cytop...</td>\n",
@@ -2669,7 +2110,6 @@
        "      <td>ENSG00000196811</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0751882', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_label': 'Highly sodium permeable po...</td>\n",
@@ -2688,7 +2128,6 @@
        "      <td>ENSG00000198947</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0340427', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': 'WP2858', 'pathway_label': 'Ec...</td>\n",
        "      <td>[{'pathway_label': 'Striated Muscle Contractio...</td>\n",
@@ -2707,13 +2146,12 @@
        "      <td>ENSG00000166736</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0001973', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': 'WP706', 'pathway_label': 'Sud...</td>\n",
        "      <td>[{'pathway_label': 'Neurotransmitter receptors...</td>\n",
        "      <td>[{'go_id': 'GO:1904602', 'go_name': 'serotonin...</td>\n",
        "      <td>[{'location_id': 'SL-0219', 'location': 'Posts...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0011206', 'disease_name...</td>\n",
+       "      <td>[{'disease_id': 'EFO_0003843', 'disease_name':...</td>\n",
        "      <td>[{'chembl_id': 'CHEMBL56564', 'drugbank_id': '...</td>\n",
        "      <td>[{'compound_name': nan, 'InChIKey': nan, 'SMIL...</td>\n",
        "      <td>[{'pubchem_assay_id': nan, 'assay_type': nan, ...</td>\n",
@@ -2736,12 +2174,6 @@
        "2  [{'anatomical_entity_id': 'UBERON_0000178', 'a...   \n",
        "3  [{'anatomical_entity_id': 'UBERON_0000178', 'a...   \n",
        "\n",
-       "                                            DisGeNET  \\\n",
-       "0  [{'disease_id': 'umls:C2350344', 'disease_name...   \n",
-       "1  [{'disease_id': 'umls:C0751882', 'disease_name...   \n",
-       "2  [{'disease_id': 'umls:C0340427', 'disease_name...   \n",
-       "3  [{'disease_id': 'umls:C0001973', 'disease_name...   \n",
-       "\n",
        "                                             MINERVA  \\\n",
        "0  [{'pathway_id': 953.0, 'pathway_label': 'Kynur...   \n",
        "1  [{'pathway_id': nan, 'pathway_label': nan, 'pa...   \n",
@@ -2749,7 +2181,7 @@
        "3  [{'pathway_id': nan, 'pathway_label': nan, 'pa...   \n",
        "\n",
        "                                        WikiPathways  \\\n",
-       "0  [{'pathway_id': 'WP3869', 'pathway_label': 'Ca...   \n",
+       "0  [{'pathway_id': 'WP5044', 'pathway_label': 'Ky...   \n",
        "1  [{'pathway_id': nan, 'pathway_label': nan, 'pa...   \n",
        "2  [{'pathway_id': 'WP2858', 'pathway_label': 'Ec...   \n",
        "3  [{'pathway_id': 'WP706', 'pathway_label': 'Sud...   \n",
@@ -2776,7 +2208,7 @@
        "0  [{'disease_id': 'umls:C0033860', 'disease_name...   \n",
        "1  [{'disease_id': 'umls:C0085631', 'disease_name...   \n",
        "2  [{'disease_id': 'umls:C0013264', 'disease_name...   \n",
-       "3  [{'disease_id': 'umls:C0011206', 'disease_name...   \n",
+       "3  [{'disease_id': 'EFO_0003843', 'disease_name':...   \n",
        "\n",
        "                               OpenTargets_Compounds  \\\n",
        "0  [{'chembl_id': 'CHEMBL259571', 'drugbank_id': ...   \n",
@@ -2820,7 +2252,7 @@
     {
      "data": {
       "text/plain": [
-       "(50, 16)"
+       "(50, 15)"
       ]
      },
      "execution_count": 32,
@@ -2896,7 +2328,6 @@
        "      <th>target</th>\n",
        "      <th>target.source</th>\n",
        "      <th>Bgee</th>\n",
-       "      <th>DisGeNET</th>\n",
        "      <th>MINERVA</th>\n",
        "      <th>WikiPathways</th>\n",
        "      <th>OpenTargets_Reactome</th>\n",
@@ -2917,9 +2348,8 @@
        "      <td>ENSG00000106546</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C2350344', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': 953.0, 'pathway_label': 'Kynur...</td>\n",
-       "      <td>[{'pathway_id': 'WP3869', 'pathway_label': 'Ca...</td>\n",
+       "      <td>[{'pathway_id': 'WP5044', 'pathway_label': 'Ky...</td>\n",
        "      <td>[{'pathway_label': 'Endogenous sterols', 'path...</td>\n",
        "      <td>[{'go_id': 'GO:0005667', 'go_name': 'transcrip...</td>\n",
        "      <td>[{'location_id': 'SL-0086', 'location': 'Cytop...</td>\n",
@@ -2936,7 +2366,6 @@
        "      <td>ENSG00000196811</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0751882', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_label': 'Highly sodium permeable po...</td>\n",
@@ -2955,7 +2384,6 @@
        "      <td>ENSG00000198947</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0340427', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': 'WP2858', 'pathway_label': 'Ec...</td>\n",
        "      <td>[{'pathway_label': 'Striated Muscle Contractio...</td>\n",
@@ -2974,13 +2402,12 @@
        "      <td>ENSG00000166736</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0001973', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': 'WP706', 'pathway_label': 'Sud...</td>\n",
        "      <td>[{'pathway_label': 'Neurotransmitter receptors...</td>\n",
        "      <td>[{'go_id': 'GO:1904602', 'go_name': 'serotonin...</td>\n",
        "      <td>[{'location_id': 'SL-0219', 'location': 'Posts...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0011206', 'disease_name...</td>\n",
+       "      <td>[{'disease_id': 'EFO_0003843', 'disease_name':...</td>\n",
        "      <td>[{'chembl_id': 'CHEMBL56564', 'drugbank_id': '...</td>\n",
        "      <td>[{'compound_name': nan, 'InChIKey': nan, 'SMIL...</td>\n",
        "      <td>[{'pubchem_assay_id': nan, 'assay_type': nan, ...</td>\n",
@@ -2993,14 +2420,13 @@
        "      <td>ENSG00000007314</td>\n",
        "      <td>Ensembl</td>\n",
        "      <td>[{'anatomical_entity_id': 'UBERON_0000178', 'a...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0751882', 'disease_name...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_id': nan, 'pathway_label': nan, 'pa...</td>\n",
        "      <td>[{'pathway_label': 'Phase 0 - rapid depolarisa...</td>\n",
-       "      <td>[{'go_id': 'GO:0019228', 'go_name': 'neuronal ...</td>\n",
+       "      <td>[{'go_id': 'GO:0035725', 'go_name': 'sodium io...</td>\n",
        "      <td>[{'location_id': 'SL-0039', 'location': 'Cell ...</td>\n",
-       "      <td>[{'disease_id': 'umls:C0037011', 'disease_name...</td>\n",
-       "      <td>[{'chembl_id': 'CHEMBL1098', 'drugbank_id': 'D...</td>\n",
+       "      <td>[{'disease_id': 'EFO_0000432', 'disease_name':...</td>\n",
+       "      <td>[{'chembl_id': 'CHEMBL1077896', 'drugbank_id':...</td>\n",
        "      <td>[{'compound_name': '3-phenyl-1h-pyrazole', 'In...</td>\n",
        "      <td>[{'pubchem_assay_id': nan, 'assay_type': nan, ...</td>\n",
        "      <td>[]</td>\n",
@@ -3024,13 +2450,6 @@
        "3  [{'anatomical_entity_id': 'UBERON_0000178', 'a...   \n",
        "4  [{'anatomical_entity_id': 'UBERON_0000178', 'a...   \n",
        "\n",
-       "                                            DisGeNET  \\\n",
-       "0  [{'disease_id': 'umls:C2350344', 'disease_name...   \n",
-       "1  [{'disease_id': 'umls:C0751882', 'disease_name...   \n",
-       "2  [{'disease_id': 'umls:C0340427', 'disease_name...   \n",
-       "3  [{'disease_id': 'umls:C0001973', 'disease_name...   \n",
-       "4  [{'disease_id': 'umls:C0751882', 'disease_name...   \n",
-       "\n",
        "                                             MINERVA  \\\n",
        "0  [{'pathway_id': 953.0, 'pathway_label': 'Kynur...   \n",
        "1  [{'pathway_id': nan, 'pathway_label': nan, 'pa...   \n",
@@ -3039,7 +2458,7 @@
        "4  [{'pathway_id': nan, 'pathway_label': nan, 'pa...   \n",
        "\n",
        "                                        WikiPathways  \\\n",
-       "0  [{'pathway_id': 'WP3869', 'pathway_label': 'Ca...   \n",
+       "0  [{'pathway_id': 'WP5044', 'pathway_label': 'Ky...   \n",
        "1  [{'pathway_id': nan, 'pathway_label': nan, 'pa...   \n",
        "2  [{'pathway_id': 'WP2858', 'pathway_label': 'Ec...   \n",
        "3  [{'pathway_id': 'WP706', 'pathway_label': 'Sud...   \n",
@@ -3057,7 +2476,7 @@
        "1  [{'go_id': 'GO:0015464', 'go_name': 'acetylcho...   \n",
        "2  [{'go_id': 'GO:0016010', 'go_name': 'dystrophi...   \n",
        "3  [{'go_id': 'GO:1904602', 'go_name': 'serotonin...   \n",
-       "4  [{'go_id': 'GO:0019228', 'go_name': 'neuronal ...   \n",
+       "4  [{'go_id': 'GO:0035725', 'go_name': 'sodium io...   \n",
        "\n",
        "                                OpenTargets_Location  \\\n",
        "0  [{'location_id': 'SL-0086', 'location': 'Cytop...   \n",
@@ -3070,15 +2489,15 @@
        "0  [{'disease_id': 'umls:C0033860', 'disease_name...   \n",
        "1  [{'disease_id': 'umls:C0085631', 'disease_name...   \n",
        "2  [{'disease_id': 'umls:C0013264', 'disease_name...   \n",
-       "3  [{'disease_id': 'umls:C0011206', 'disease_name...   \n",
-       "4  [{'disease_id': 'umls:C0037011', 'disease_name...   \n",
+       "3  [{'disease_id': 'EFO_0003843', 'disease_name':...   \n",
+       "4  [{'disease_id': 'EFO_0000432', 'disease_name':...   \n",
        "\n",
        "                               OpenTargets_Compounds  \\\n",
        "0  [{'chembl_id': 'CHEMBL259571', 'drugbank_id': ...   \n",
        "1  [{'chembl_id': 'CHEMBL1200641', 'drugbank_id':...   \n",
        "2  [{'chembl_id': 'CHEMBL2108278', 'drugbank_id':...   \n",
        "3  [{'chembl_id': 'CHEMBL56564', 'drugbank_id': '...   \n",
-       "4  [{'chembl_id': 'CHEMBL1098', 'drugbank_id': 'D...   \n",
+       "4  [{'chembl_id': 'CHEMBL1077896', 'drugbank_id':...   \n",
        "\n",
        "                       MolMeDB_transporter_inhibitor  \\\n",
        "0  [{'compound_name': nan, 'InChIKey': nan, 'SMIL...   \n",
@@ -3115,19 +2534,7 @@
    "cell_type": "code",
    "execution_count": 36,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
-      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
-      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
-      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pygraph = generator.networkx_graph(fuse_df)"
    ]
@@ -3141,7 +2548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/gene_to_graph_workflow.ipynb
+++ b/examples/gene_to_graph_workflow.ipynb
@@ -69,9 +69,9 @@
     "    OPENTARGETS_GO_COL,\n",
     "    OPENTARGETS_LOCATION_COL,\n",
     "    OPENTARGETS_REACTOME_COL,\n",
+    "    PUBCHEM_ASSAYS_COL,\n",
     "    STRING,\n",
     "    WIKIPATHWAYS,\n",
-    "    PUBCHEM_ASSAYS_COL,\n",
     ")\n",
     "from pyBiodatafuse.graph import generator\n",
     "from pyBiodatafuse.utils import combine_sources"

--- a/src/pyBiodatafuse/graph/generator.py
+++ b/src/pyBiodatafuse/graph/generator.py
@@ -96,13 +96,9 @@ def merge_node(g, node_label, node_attrs):
         g.add_node(node_label, attr_dict=node_attrs)
     else:
         if "attr_dict" in g.nodes[node_label]:
-
             for k, v in node_attrs.items():
-
                 if k in g.nodes[node_label]["attr_dict"]:
-
                     if g.nodes[node_label]["attr_dict"][k] is not None:
-
                         if isinstance(v, str):
                             v_list = g.nodes[node_label]["attr_dict"][k].split("|")
                             v_list.append(v)
@@ -217,7 +213,7 @@ def add_disgenet_disease_subgraph(g, gene_node_label, annot_list):
             annot_node_attrs["id"] = annot["disease_id"]
             annot_node_attrs["evidence_source"] = annot["evidence_source"]
 
-            #g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            # g.add_node(annot_node_label, attr_dict=annot_node_attrs)
             merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = DISGENET_EDGE_ATTRS.copy()
@@ -257,7 +253,7 @@ def add_opentargets_disease_subgraph(g, gene_node_label, annot_list):
             annot_node_attrs["id"] = annot["disease_id"]
             annot_node_attrs["therapeutic_areas"] = annot["therapeutic_areas"]
 
-            #g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            # g.add_node(annot_node_label, attr_dict=annot_node_attrs)
             merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = OPENTARGETS_DISEASE_EDGE_ATTRS

--- a/src/pyBiodatafuse/graph/generator.py
+++ b/src/pyBiodatafuse/graph/generator.py
@@ -85,6 +85,36 @@ def load_dataframe_from_pickle(pickle_path: str) -> pd.DataFrame:
     return df
 
 
+def merge_node(g, node_label, node_attrs):
+    """Merge the attr_dict of a newly added node to the graph on duplication, otherwise, add the new node.
+
+    :param g: the graph to which the node will be added.
+    :param node_label: node label.
+    :param node_attrs: dictionary of node attributes.
+    """
+    if node_label not in g.nodes():
+        g.add_node(node_label, attr_dict=node_attrs)
+    else:
+        if "attr_dict" in g.nodes[node_label]:
+
+            for k, v in node_attrs.items():
+
+                if k in g.nodes[node_label]["attr_dict"]:
+
+                    if g.nodes[node_label]["attr_dict"][k] is not None:
+
+                        if isinstance(v, str):
+                            v_list = g.nodes[node_label]["attr_dict"][k].split("|")
+                            v_list.append(v)
+                            g.nodes[node_label]["attr_dict"][k] = "|".join(list(set(v_list)))
+                    else:
+                        g.nodes[node_label]["attr_dict"][k] = v
+                else:
+                    g.nodes[node_label]["attr_dict"][k] = v
+        else:
+            g.add_node(node_label, attr_dict=node_attrs)
+
+
 def add_bgee_subgraph(g, gene_node_label, annot_list):
     """Construct part of the graph by linking the gene to a list of annotation entities (disease, drug ..etc).
 
@@ -430,7 +460,8 @@ def add_opentargets_compound_subgraph(g, gene_node_label, annot_list):
             if not pd.isna(annot["adverse_effect_count"]):
                 annot_node_attrs["adverse_effect_count"] = annot["adverse_effect_count"]
 
-            g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            # g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = OPENTARGETS_COMPOUND_EDGE_ATTRS.copy()
             edge_attrs["label"] = annot["relation"]
@@ -510,7 +541,8 @@ def add_molmedb_gene_inhibitor(g, gene_node_label, annot_list):
             if not pd.isna(annot["source_pmid"]):
                 annot_node_attrs["source_pmid"] = annot["source_pmid"]
 
-            g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            # g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = MOLMEDB_COMPOUND_EDGE_ATTRS.copy()
 
@@ -551,7 +583,8 @@ def add_pubchem_assay(g, gene_node_label, annot_list):
             if not pd.isna(annot["SMILES"]):
                 annot_node_attrs["SMILES"] = annot["SMILES"]
 
-            g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            # g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = PUBCHEM_EDGE_ATTRS.copy()
             edge_attrs["assay_type"] = annot["assay_type"]

--- a/src/pyBiodatafuse/graph/generator.py
+++ b/src/pyBiodatafuse/graph/generator.py
@@ -217,7 +217,8 @@ def add_disgenet_disease_subgraph(g, gene_node_label, annot_list):
             annot_node_attrs["id"] = annot["disease_id"]
             annot_node_attrs["evidence_source"] = annot["evidence_source"]
 
-            g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            #g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = DISGENET_EDGE_ATTRS.copy()
             edge_attrs["score"] = edge_attrs["score"]
@@ -256,7 +257,8 @@ def add_opentargets_disease_subgraph(g, gene_node_label, annot_list):
             annot_node_attrs["id"] = annot["disease_id"]
             annot_node_attrs["therapeutic_areas"] = annot["therapeutic_areas"]
 
-            g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            #g.add_node(annot_node_label, attr_dict=annot_node_attrs)
+            merge_node(g, annot_node_label, annot_node_attrs)
 
             edge_attrs = OPENTARGETS_DISEASE_EDGE_ATTRS
 


### PR DESCRIPTION
This function check if there is a node with the same main_label already exists in the graph. If so, the values of the matching keys in the node_attr dictionaries are concatenated and the values of the new keys are just added to the current node in the graph. If the added node does not already exists, it is just added to the graph. 

This function is applied to the graph generation functions of OpenTargets, MolMeDB and PubChem, since they have "compound_cid" as the main label.