### PR TITLE
Restore PubChem output_datasource to fix bridgedb metabolite mapping

### DIFF
--- a/src/pyBiodatafuse/id_mapper.py
+++ b/src/pyBiodatafuse/id_mapper.py
@@ -115,6 +115,7 @@ def bridgedb_xref(
             "Ensembl",
             "HGNC Accession Number",
             "HGNC",
+            "PubChem Compound"
         ]
     else:
         assert isinstance(output_datasource, list), "output_datasource must be a list"

--- a/src/pyBiodatafuse/id_mapper.py
+++ b/src/pyBiodatafuse/id_mapper.py
@@ -109,13 +109,15 @@ def bridgedb_xref(
         raise ValueError("Please provide the identifier datasource, e.g. HGNC")
 
     if output_datasource is None or "All":
-        output_datasource = [
-            "Uniprot-TrEMBL",
-            "NCBI Gene",
-            "Ensembl",
-            "HGNC Accession Number",
-            "HGNC",
-            "PubChem Compound"
+        data_sources = read_resource_files()
+        output_datasource = list(data_sources["source")
+#        output_datasource = [
+#            "Uniprot-TrEMBL",
+#            "NCBI Gene",
+#            "Ensembl",
+#            "HGNC Accession Number",
+#            "HGNC",
+#            "PubChem Compound"
         ]
     else:
         assert isinstance(output_datasource, list), "output_datasource must be a list"

--- a/src/pyBiodatafuse/id_mapper.py
+++ b/src/pyBiodatafuse/id_mapper.py
@@ -110,7 +110,7 @@ def bridgedb_xref(
 
     if output_datasource is None or "All":
         data_sources = read_resource_files()
-        output_datasource = list(data_sources["source")
+        output_datasource = list(data_sources["source"])
 #        output_datasource = [
 #            "Uniprot-TrEMBL",
 #            "NCBI Gene",

--- a/src/pyBiodatafuse/id_mapper.py
+++ b/src/pyBiodatafuse/id_mapper.py
@@ -118,7 +118,7 @@ def bridgedb_xref(
 #            "HGNC Accession Number",
 #            "HGNC",
 #            "PubChem Compound"
-        ]
+#        ]
     else:
         assert isinstance(output_datasource, list), "output_datasource must be a list"
 


### PR DESCRIPTION
The metabolite mapping didn't work due to the changed line.

Additionally, why not retrieve the list from datasources.tsv?