### PR TITLE
Directly use Bioregistry for updating datasources.csv

### DIFF
--- a/scripts/update_datasources.py
+++ b/scripts/update_datasources.py
@@ -9,7 +9,7 @@ Usage:
 Requirements:
     - Python 3.9-3.10
     - pandas
-    - requests
+    - bioregistry
 
 Notes:
     - The Bioregistry API is accessed using the URL template:
@@ -19,11 +19,10 @@ Notes:
 
 Raises:
     - FileNotFoundError: If the `resources/datasources.csv` file is not found.
-    - requests.exceptions.RequestException: If there is an issue with the API request.
 """
 
+import bioregistry
 import pandas as pd
-import requests
 
 
 def update_datasources_file():
@@ -31,37 +30,22 @@ def update_datasources_file():
     Updates the datasources.csv file with pattern data fetched from the Bioregistry API.
 
     Note:
-        - The Bioregistry API is accessed using the URL template:
-          "https://bioregistry.io/api/registry/{prefix}?format=json".
+        - The Bioregistry API is accessed via :func:`bioregistry.get_pattern`
         - If a prefix does not have a corresponding pattern in the API, an empty string is used.
 
     Raises:
         FileNotFoundError: If the datasources.csv file is not found.
-        requests.exceptions.RequestException: If there is an issue with the API request.
     """
-    url_bioregistry = "https://bioregistry.io/api/registry/{}?format=json"
 
     # Access the datasources.csv file using importlib.resources
     csv_path = "resources/datasources.csv"
-    with open(csv_path) as f:
-        # Read the CSV file using pandas
-        df = pd.read_csv(f)
+ 
+    df = pd.read_csv(csv_path)
 
-        # Add a new column "pattern" and fetch data from Bioregistry
-        def fetch_pattern(prefix):
-            if pd.notna(prefix):
-                response = requests.get(url_bioregistry.format(prefix))
-                if response.status_code == 200:
-                    print(response.json().get("pattern", ""))
-                    return response.json().get("pattern", "")
-                else:
-                    print("bad request for ", prefix)
-            return ""
+    df["pattern"] = df["prefix"].map(bioregistry.get_pattern, na_action="ignore")
 
-        df["pattern"] = df["prefix"].map(fetch_pattern)
-
-        # Write the updated data back to the CSV file
-        df.to_csv(csv_path, index=False)
+    # Write the updated data back to the CSV file
+    df.to_csv(csv_path, index=False)
 
 
 if __name__ == "__main__":

--- a/scripts/update_datasources.py
+++ b/scripts/update_datasources.py
@@ -1,20 +1,27 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "bioregistry",
+#     "pandas",
+# ]
+# ///
+#
+
 """
-update_datasources.py
+This script updates the `resources/datasources.csv` file with pattern data fetched from the Bioregistry.
 
-This script updates the `resources/datasources.csv` file with pattern data fetched from the Bioregistry API.
+This script can be run with ``uv``, which automatically creates
+an environment with the appropriate dependencies using:
 
-Usage:
-    python update_datasources.py
+.. code-block:: console
 
-Requirements:
-    - Python 3.9-3.10
-    - pandas
-    - bioregistry
+    $ git clone https://github.com/BioDataFuse/pyBiodatafuse
+    $ cd pyBiodatafuse
+    $ uv run update_datasources.py
 
 Notes:
-    - The Bioregistry API is accessed using the URL template:
-      "https://bioregistry.io/api/registry/{prefix}?format=json".
-    - If a prefix does not have a corresponding pattern in the API, an empty string is used.
+    - Patterns are accesed via the Bioregistry package's :func:`bioregistry.get_pattern`
+    - If a prefix does not have a corresponding pattern in the Bioregistry, an empty string is used.
     - This script is intended for occasional use to update the resource file.
 
 Raises:
@@ -23,29 +30,30 @@ Raises:
 
 import bioregistry
 import pandas as pd
+from pathlib import Path
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.resolve()
+PATH = ROOT.joinpath("src", "pyBiodatafuse", "resources", "datasources.csv")
 
 
 def update_datasources_file():
     """
-    Updates the datasources.csv file with pattern data fetched from the Bioregistry API.
+    Updates the datasources.csv file with pattern data fetched from the Bioregistry.
 
     Note:
-        - The Bioregistry API is accessed via :func:`bioregistry.get_pattern`
-        - If a prefix does not have a corresponding pattern in the API, an empty string is used.
+        - Patterns are accesed via the Bioregistry package's :func:`bioregistry.get_pattern`
+        - If a prefix does not have a corresponding pattern in the Bioregistry, an empty string is used.
 
     Raises:
         FileNotFoundError: If the datasources.csv file is not found.
     """
-
-    # Access the datasources.csv file using importlib.resources
-    csv_path = "resources/datasources.csv"
- 
-    df = pd.read_csv(csv_path)
+    df = pd.read_csv(PATH)
 
     df["pattern"] = df["prefix"].map(bioregistry.get_pattern, na_action="ignore")
 
     # Write the updated data back to the CSV file
-    df.to_csv(csv_path, index=False)
+    df.to_csv(PATH, index=False)
 
 
 if __name__ == "__main__":

--- a/src/pyBiodatafuse/resources/datasources.csv
+++ b/src/pyBiodatafuse/resources/datasources.csv
@@ -11,13 +11,13 @@ Q,RefSeq,gene,refseq,"^(((AC|AP|NC|NG|NM|NP|NR|NT|NW|WP|XM|XP|XR|YP|ZP)_\d+)|(NZ
 Rf,Rfam,gene,rfam,^RF\d{5}$
 R,RGD,gene,rgd,"^\d{4,}$"
 D,SGD,gene,sgd,^((S\d+$)|(Y[A-Z]{2}\d{3}[a-zA-Z](\-[A-Z])?))$
-Uc,UCSC Genome Browser,gene,ucsc,^ucsc:.+$
+Uc,UCSC Genome Browser,gene,ucsc,
 Np,NCBI Protein,gene,ncbi_protein,^\w+_?\d+(.\d+)?$
 Pd,PDB,gene,pdb,^[0-9][A-Za-z0-9]{3}$
 Pf,Pfam,gene,pfam,^PF\d{5}$
 S,Uniprot-TrEMBL,gene,uniprot,"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\.\d+)?$"
 Sp,Uniprot-SwissProt,gene,uniprot,"^([A-N,R-Z][0-9]([A-Z][A-Z, 0-9][A-Z, 0-9][0-9]){1,2})|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9])(\.\d+)?$"
-X,Affy,gene,affy.probeset,"^\d{4,}((_[asx])?_at)$"
+X,Affy,gene,affy.probeset,"^\d{4,}((_[asx])?_at)?$"
 Ag,Agilent,gene,agilent.probe,^A_\d+_.+$
 Il,Illumina,gene,illumina.probe,^ILMN_\d+$
 T,Gene Ontology,gene,go,^\d{7}$
@@ -33,11 +33,11 @@ Ck,KEGG Compound,metabolite,kegg,"^([CHDEGTMKR]\d+)|(\w+:[\w\d\.-]*)|([a-z]{3,5}
 Kd,KEGG Drug,metabolite,kegg,"^([CHDEGTMKR]\d+)|(\w+:[\w\d\.-]*)|([a-z]{3,5})|(\w{2,4}\d{5})$"
 Kl,KEGG Glycan,metabolite,kegg,"^([CHDEGTMKR]\d+)|(\w+:[\w\d\.-]*)|([a-z]{3,5})|(\w{2,4}\d{5})$"
 Lm,LIPID MAPS,metabolite,lipidmaps,"^LM(FA|GL|GP|SP|ST|PR|SL|PK)[0-9]{4}([0-9a-zA-Z]{4,6})?$"
-Lb,LipidBank,metabolite,lipidbank,^(?!ENS)\w+\d+$
+Lb,LipidBank,metabolite,lipidbank,^\w+\d+$
 Pgd,PharmGKB Drug,metabolite,pharmgkb.drug,^PA\d+$
 Cpc,PubChem Compound,metabolite,pubchem,^\d+$
 Cps,PubChem Substance,metabolite,pubchem,^\d+$
 Sl,SwissLipids,metabolite,swisslipids,^\d+$
-Td,TTD Drug,metabolite,ttd.drug,^DAP\d+$
+Td,TTD Drug,metabolite,ttd.drug,^\w+$
 Wd,Wikidata,metabolite,wikidata,^(Q|P|E|L)\d+$
-Wi,Wikipedia,metabolite,wikipedia,
+Wi,Wikipedia,metabolite,wikipedia,^\S+$


### PR DESCRIPTION
I trawl GitHub for usages of the Bioregistry, and found this one that could be simplified and improved.

This PR replaces calls to the Bioregistry API with direct usage of the Bioregistry Python package. It also uses more modern methods (with `uv`) for specifying script dependencies and gives better hints on how to run the update script.

This PR also runs the update script.